### PR TITLE
Handle data-confirm attribute in elements that submit forms

### DIFF
--- a/vendor/assets/javascripts/prototype_ujs.js
+++ b/vendor/assets/javascripts/prototype_ujs.js
@@ -161,7 +161,12 @@
     }
   });
 
-  document.on("click", "form input[type=submit], form button[type=submit], form button:not([type])", function(event, button) {
+  document.on("click", "form input[type=submit], form input[type=image], form button[type=submit], form button:not([type])", function(event, button) {
+    if (!allowAction(button)){
+      event.stop();
+      return false;
+    }
+    
     // register the pressed submit button
     event.findElement('form').store('rails:submit-button', button.name || false);
   });


### PR DESCRIPTION
Handle data-confirm attribute added by ActionView::Helpers::FormTagHelper#submit_tag, image_submit_tag, and button_tag.   The existing code appears to check for the data-confirm attribute on the form element, which doesnt appear to be correct according to the options listed for form_tag in the rails api docs, but I'm not 100% sure so I havent removed that
