### PR TITLE
Fix button name submission when using the "disable-with" feature

### DIFF
--- a/vendor/assets/javascripts/prototype_ujs.js
+++ b/vendor/assets/javascripts/prototype_ujs.js
@@ -130,6 +130,19 @@
 
   function disableFormElements(form) {
     form.select('input[type=submit][data-disable-with]').each(function(input) {
+      if (input.name == form.retrieve('rails:submit-button')) {
+        if (window.hiddenCommit) {
+          window.hiddenCommit.setAttribute('name', input.name);
+          window.hiddenCommit.setAttribute('value', input.value);
+        } else {
+          hiddenCommit = document.createElement('input');
+          hiddenCommit.type = 'hidden';
+          hiddenCommit.value = input.value;
+          hiddenCommit.name = input.name;
+          form.appendChild(hiddenCommit);
+        }
+      }
+
       input.store('rails:original-value', input.getValue());
       input.setValue(input.readAttribute('data-disable-with')).disable();
     });


### PR DESCRIPTION
In Rails 2.2 a fix was put in for the case when a button has disable-with set: the library needs to add a hidden form field with the same name and value as the button had, because disabled form elements aren't included in the serialized form contents.

This fix was lost in the prototype-rails extraction.  This patch adds it back.

We've been using it for the last year and it merges cleanly to master still.
