### PR TITLE
I've applied a patch that fixes a conflict with devise:install

### DIFF
--- a/lib/prototype-rails/on_load_action_view.rb
+++ b/lib/prototype-rails/on_load_action_view.rb
@@ -13,7 +13,7 @@ ActionView::Base.class_eval do
   include ActionView::Helpers::PrototypeHelper
   include ActionView::Helpers::ScriptaculousHelper
 end
-if Rails.env.test?
+if ActionView::TestCase.present?
   ActionView::TestCase.class_eval do
     include ActionView::Helpers::PrototypeHelper
     include ActionView::Helpers::ScriptaculousHelper


### PR DESCRIPTION
This patch: https://github.com/rails/prototype-rails/commit/fcbf454f426a202fa4633c10ec08d0cb89996e0b fixes a problem I had with Devise install. Without it, I would get a NoMethodError which traces back to prototype-rails.on_load_action_view.rb:17 after trying to run rails g devise:install
