### PR TITLE
Fix conflict with Devise generator

### DIFF
--- a/lib/prototype-rails/on_load_action_view.rb
+++ b/lib/prototype-rails/on_load_action_view.rb
@@ -14,9 +14,11 @@ ActionView::Base.class_eval do
   include ActionView::Helpers::ScriptaculousHelper
 end
 
-ActionView::TestCase.class_eval do
-  include ActionView::Helpers::PrototypeHelper
-  include ActionView::Helpers::ScriptaculousHelper
+if ActionView::TestCase.present?
+  ActionView::TestCase.class_eval do
+    include ActionView::Helpers::PrototypeHelper
+    include ActionView::Helpers::ScriptaculousHelper
+  end
 end
 
 ActionView::Template.register_template_handler :rjs, ActionView::Template::Handlers::RJS.new

--- a/lib/prototype-rails/on_load_action_view.rb
+++ b/lib/prototype-rails/on_load_action_view.rb
@@ -14,7 +14,7 @@ ActionView::Base.class_eval do
   include ActionView::Helpers::ScriptaculousHelper
 end
 
-if ActionView::TestCase.present?
+if defined? ActionView::TestCase
   ActionView::TestCase.class_eval do
     include ActionView::Helpers::PrototypeHelper
     include ActionView::Helpers::ScriptaculousHelper


### PR DESCRIPTION
(This is a revised version of the original pull request, cleaning up the commit history to only the needed change.)

This patch allows Prototype-Rails to work with the latest Devise generators. As requested, this no longer uses Rails.env to check whether TestCase is loaded.