### PR TITLE
Fix warning raised when building 4.2 version

### DIFF
--- a/prototype-rails.gemspec
+++ b/prototype-rails.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   spec.author   = 'Xavier Noria'
   spec.email    = 'fxn@hashref.com'
 
-  spec.files = %w(README Rakefile Gemfile MIT-LICENSE) + Dir['lib/**/*', 'vendor/**/*', 'test/**/*']
+  spec.files = %w(README.md Rakefile Gemfile MIT-LICENSE) + Dir['lib/**/*', 'vendor/**/*', 'test/**/*']
 
   spec.add_dependency('rails', '~> 4.0')
   spec.add_development_dependency('mocha')


### PR DESCRIPTION
Fix README extensions on gemspec, raising a warning when building the gem.
This was introduced by this commit c548aa4.