### PR TITLE
Updated for Rails 4.2.0

### DIFF
--- a/lib/prototype-rails/selector_assertions.rb
+++ b/lib/prototype-rails/selector_assertions.rb
@@ -1,6 +1,6 @@
 require 'active_support/core_ext/module/aliasing'
 require 'action_dispatch/testing/assertions'
-require 'action_dispatch/testing/assertions/selector'
+require 'rails/dom/testing/assertions/selector_assertions'
 
 #--
 # Copyright (c) 2006 Assaf Arkin (http://labnotes.org)


### PR DESCRIPTION
Fixed deprecation warning ActionDispatch::Assertions::SelectorAssertions has been extracted to the rails-dom-testing gem.