### PR TITLE
Add compatibility with Rails 5+

### DIFF
--- a/prototype-rails.gemspec
+++ b/prototype-rails.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
 
   spec.files = %w(README.md Rakefile Gemfile MIT-LICENSE) + Dir['lib/**/*', 'vendor/**/*', 'test/**/*']
 
-  spec.add_dependency('rails', '~> 4.0')
+  spec.add_dependency('rails')
   spec.add_development_dependency('mocha')
   spec.license = "MIT"
 end


### PR DESCRIPTION
There's nothing in `prototype-rails` code that prevents it from working in Rails 5+. Remove the restriction from the gemspec so any legacy applications willing to use new Rails 5 features have an upgrade path without having to rewrite their code.

Before it gets merged (if ever gets merged), anyone who needs to use this version of `prototype-rails` is welcome to use my fork:

```ruby
gem 'prototype-rails', git: 'https://github.com/Nowaker/prototype-rails.git', branch: '5.0'
```